### PR TITLE
Added deprecation message in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![NPM version](https://badge.fury.io/js/murmurhash3js.png)](http://badge.fury.io/js/murmurhash3js) [![Build Status](https://travis-ci.org/pid/murmurHash3js.png)](https://travis-ci.org/pid/murmurhash3js)
+### Deprecated: This fork has been deprecated in favor of the original repository
+### Versions > 3.0.1 of the murmurhash3js npm package will now be published from https://github.com/karanlyons/murmurHash3.js
+
+
 
 MurmurHash3js
 =============


### PR DESCRIPTION
Added deprecation message in readme so the new versions of murmurhash3js can be published from the original repo:

Here is a list of tasks needed to move over the repository
- [ ] Publish v3.2.0 of murmurhash3js based on code code in this repo: https://github.com/karanlyons/murmurHash3.js
- [ ] Add deprecated message in description of this repo and make it readonly
- [ ] Merge this PR